### PR TITLE
Fixed bug in IE8

### DIFF
--- a/lib/stround.js
+++ b/lib/stround.js
@@ -97,7 +97,7 @@ export function parse(strnum) {
   }
 
   return [
-    match[1] !== undefined,
+    match[1] === NEG_PATTERN,
     match[2],
     match[3] || ''
   ];


### PR DESCRIPTION
For example:
stround.format(stround.parse(199.999));
returns -200

The bug in match method is described here http://blogs.perl.org/users/mauke/2010/11/two-regexp-bugs-in-internet-explorer-8.html
